### PR TITLE
Licenses used per host

### DIFF
--- a/src/components/licenses/used/hosts/UsedLicensesHost.vue
+++ b/src/components/licenses/used/hosts/UsedLicensesHost.vue
@@ -34,11 +34,12 @@
 
       <template slot="bodyData" slot-scope="rowData">
         <HostLink :hostname="rowData.scope.hostname" />
-        <td v-tooltip.bottom="options(rowData.scope.databases)">
+        <!-- <td v-tooltip.bottom="options(rowData.scope.databases)">
           <a @click.prevent="openModal(rowData.scope)" class="is-block">
             <span v-html="highlight(rowData.scope.databases)" />
           </a>
-        </td>
+        </td> -->
+        <TdContent :value="rowData.scope.databases" />
         <TdContent :value="rowData.scope.licenseTypeID" />
         <TdContent :value="rowData.scope.description" />
         <TdContent :value="rowData.scope.metric" />

--- a/src/components/licenses/used/hosts/UsedLicensesHost.vue
+++ b/src/components/licenses/used/hosts/UsedLicensesHost.vue
@@ -17,7 +17,7 @@
     >
       <template slot="headData">
         <v-th sortKey="hostname">{{ $t('common.collumns.hostname') }}</v-th>
-        <v-th sortKey="dbsQty">{{ $t('common.collumns.databases') }}</v-th>
+        <v-th sortKey="databases">{{ $t('common.collumns.databases') }}</v-th>
         <v-th sortKey="licenseTypeID">
           {{ $t('common.collumns.partNumber') }}
         </v-th>
@@ -34,9 +34,9 @@
 
       <template slot="bodyData" slot-scope="rowData">
         <HostLink :hostname="rowData.scope.hostname" />
-        <td v-tooltip.bottom="options(rowData.scope.dbsQty)">
+        <td v-tooltip.bottom="options(rowData.scope.databases)">
           <a @click.prevent="openModal(rowData.scope)" class="is-block">
-            <span v-html="highlight(rowData.scope.dbsQty)" />
+            <span v-html="highlight(rowData.scope.databases)" />
           </a>
         </td>
         <TdContent :value="rowData.scope.licenseTypeID" />
@@ -47,7 +47,7 @@
 
       <exportButton
         slot="export"
-        url="hosts/technologies/all/databases/licenses-used"
+        url="/hosts/technologies/all/databases/licenses-used-per-host"
         expName="licensesUsedPerHosts"
       />
     </FullTable>
@@ -94,7 +94,7 @@ export default {
       keys: [
         'hostname',
         'licenseTypeID',
-        'dbsQty',
+        'databases',
         'description',
         'metric',
         'usedLicenses'
@@ -106,6 +106,7 @@ export default {
   },
   methods: {
     openModal(info) {
+      console.log(info)
       this.$buefy.modal.open({
         component: UsedLicensesHostModal,
         hasModalCard: true,

--- a/src/components/licenses/used/hosts/UsedLicensesHostFilters.vue
+++ b/src/components/licenses/used/hosts/UsedLicensesHostFilters.vue
@@ -10,8 +10,8 @@
 
     <CustomField :label="$t('common.fields.dbs')">
       <CustomSlider
-        v-model="filters.dbsQty"
-        :ticks="[mindbsQty, maxdbsQty]"
+        v-model="filters.databases"
+        :ticks="[mindatabases, maxdatabases]"
         :steps="1"
       />
     </CustomField>
@@ -47,7 +47,7 @@ export default {
     return {
       autocompletes: ['hostname'],
       selects: ['licenseTypeID', 'description', 'metric'],
-      sliders: ['dbsQty']
+      sliders: ['databases']
     }
   },
   created() {

--- a/src/store/modules/licenses/licenses-used.js
+++ b/src/store/modules/licenses/licenses-used.js
@@ -14,37 +14,7 @@ export const getters = {
     return getters.filteredOrNot(cleanData)
   },
   getUsedLicensesByHost: (state, getters) => {
-    let cleanData = _.without(state.hostsLicensesUsed, undefined, null, '')
-    const finalData = []
-
-    cleanData = _.groupBy(cleanData, 'licenseTypeID')
-    _.forEach(cleanData, (typeVal, typeIndex) => {
-      let groupByHost = _.groupBy(typeVal, 'hostname')
-      _.forEach(groupByHost, (hostVal, hostIndex) => {
-        let DBs = []
-        let usedLicenses = null
-
-        _.forEach(hostVal, val => {
-          if (val.hostname === hostIndex && val.licenseTypeID === typeIndex) {
-            DBs.push({ dbName: val.dbName })
-            usedLicenses = val.usedLicenses
-          }
-        })
-
-        finalData.push({
-          dbsQty: DBs.length,
-          databases: DBs,
-          licenseTypeID: typeIndex,
-          description: getters.returnMetricAndDescription(typeIndex)
-            .description,
-          metric: getters.returnMetricAndDescription(typeIndex).metric,
-          hostname: hostIndex,
-          usedLicenses: usedLicenses
-        })
-        DBs = []
-      })
-    })
-    return getters.filteredOrNot(finalData)
+    return getters.filteredOrNot(state.hostsLicensesUsed)
   },
   getUsedLicensesByCluster: (state, getters) => {
     return getters.filteredOrNot(state.clustersLicensesUsed)
@@ -52,8 +22,10 @@ export const getters = {
 }
 
 export const mutations = {
-  SET_LICENSE_LIST: (state, payload) => {
+  SET_LICENSE_DATABASES: (state, payload) => {
     state.dbsLicensesUsed = payload
+  },
+  SET_LICENSES_HOST: (state, payload) => {
     state.hostsLicensesUsed = payload
   },
   SET_LICENSES_CLUSTER: (state, payload) => {
@@ -75,7 +47,7 @@ export const actions = {
     )
     const response = await licensesList.data.usedLicenses
 
-    let setLicensesInfo = _.map(response, val => {
+    let licensesPerDatabase = _.map(response, val => {
       return {
         ...val,
         description: getters.returnMetricAndDescription(val.licenseTypeID)
@@ -84,7 +56,21 @@ export const actions = {
       }
     })
 
-    commit('SET_LICENSE_LIST', setLicensesInfo)
+    commit('SET_LICENSE_DATABASES', licensesPerDatabase)
+  },
+  async getLicensesPerHost({ commit, getters }) {
+    const licensePerHost = await axiosDefault.get(
+      '/hosts/technologies/all/databases/licenses-used-per-host',
+      {
+        params: {
+          'older-than': getters.getActiveFilters.date,
+          environment: getters.getActiveFilters.environment,
+          location: getters.getActiveFilters.location
+        }
+      }
+    )
+    const response = await licensePerHost.data.usedLicenses
+    commit('SET_LICENSES_HOST', response)
   },
   async getLicensesCluster({ commit }) {
     // const licensesCluster = await axiosDefault.get(

--- a/src/views/licenses/LicensesUsed.vue
+++ b/src/views/licenses/LicensesUsed.vue
@@ -43,6 +43,7 @@ export default {
 
     await this.getLicensesList()
       .then(() => {
+        this.getLicensesPerHost()
         this.getLicensesCluster()
       })
       .then(() => (this.isMounted = true))
@@ -51,6 +52,7 @@ export default {
     ...mapActions([
       'getLicensesList',
       'getAgreementParts',
+      'getLicensesPerHost',
       'getLicensesCluster'
     ]),
     onTabChange() {


### PR DESCRIPTION
Updating hots tab on licenses used to use the API /hosts/technologies/all/databases/licenses-used-per-host
Missing click on databases number because the API needs an update to bring an array with the names of the databases.